### PR TITLE
Fix minor issues with event creation

### DIFF
--- a/packages/frontend/src/components/layout/Modal/Modal.module.sass
+++ b/packages/frontend/src/components/layout/Modal/Modal.module.sass
@@ -8,7 +8,7 @@
     background-color: #30324059
     transition: all .3s ease-out
     box-sizing: border-box
-    position: absolute
+    position: fixed
     top: 0
     left: 0
 

--- a/packages/frontend/src/components/layout/Modal/Modal.tsx
+++ b/packages/frontend/src/components/layout/Modal/Modal.tsx
@@ -2,6 +2,7 @@ import css from './Modal.module.sass';
 import { Button } from '../../elements/Button/Button';
 import { Loader } from '../../elements/Loader/Loader';
 import { getClassesList } from 'src/utils/getClassesList';
+import { useEffect } from 'react';
 
 interface ModalProps {
   cancelButtonMessage: string;
@@ -30,6 +31,15 @@ export const Modal = ({
 }: ModalProps) => {
   const submitClassNames = getClassesList(css.modalButton, submitClassName);
   const cancelClassNames = getClassesList(css.modalButton, cancelClassName);
+
+  useEffect(() => {
+    // prevents scrolling when modal is open
+    document.body.style.overflow = 'hidden';
+
+    return () => {
+      document.body.style.overflow = 'auto';
+    };
+  }, []);
 
   return (
     <div className={css.modalWrapper}>

--- a/packages/frontend/src/constants.ts
+++ b/packages/frontend/src/constants.ts
@@ -111,3 +111,6 @@ export const MONTHS = [
   { name: translation.november, value: Month.November },
   { name: translation.december, value: Month.December },
 ];
+
+export const DEFAULT_MIN_AGE = 16;
+export const DEFAULT_MAX_AGE = 61;

--- a/packages/frontend/src/redux/actions.ts
+++ b/packages/frontend/src/redux/actions.ts
@@ -10,7 +10,7 @@ import {
   SET_MANAGE_USERS_SCROLL_SIZE,
   SET_SHOW_MENU,
   SET_USER_SEARCH_INPUT,
-  UPDATE_USERS_LIST
+  UPDATE_USERS_LIST,
 } from './types';
 
 export const setEditor = (editor: IUser): IAction => ({
@@ -42,12 +42,12 @@ export const setManageUsersSearchInput = (searchInput: string): IAction => ({
 export const setManageUsersScrollSize = (scrollSize: number): IAction => ({
   type: SET_MANAGE_USERS_SCROLL_SIZE,
   payload: scrollSize,
-})
+});
 
 export const setManageUsersScrollDirection = (scrollDirection: ScrollDirection): IAction => ({
   type: SET_MANAGE_USERS_SCROLL_DIRECTION,
   payload: scrollDirection,
-})
+});
 
 // EVENTS
 
@@ -56,7 +56,12 @@ export const setEventsLoading = (loading: boolean): IAction => ({
   payload: loading,
 });
 
-export const saveEvents = (events: IEvent[], isError: boolean, isLast: boolean, initialized: boolean = true): IAction => ({
+export const saveEvents = (
+  events: IEvent[],
+  isError: boolean,
+  isLast: boolean,
+  initialized: boolean = true
+): IAction => ({
   type: SAVE_EVENTS,
   payload: { isError, isLast, data: events, initialized },
 });

--- a/packages/frontend/src/utils/createEvent.ts
+++ b/packages/frontend/src/utils/createEvent.ts
@@ -1,15 +1,17 @@
 import { collection, doc, setDoc } from 'firebase/firestore';
-import { firebaseDb } from 'src/main';
-import { IEvent } from 'src/types';
-import { showNotification } from './showNotification';
+import { getDownloadURL, getStorage, ref, uploadBytes } from 'firebase/storage';
 import {
+  DEFAULT_MAX_AGE,
+  DEFAULT_MIN_AGE,
   FirebaseCollection,
   NOTIFICATIONS,
   STORAGE_BUCKET,
   STORAGE_IMAGES_PATH,
 } from 'src/constants';
+import { firebaseDb } from 'src/main';
+import { EventStatus, IEvent } from 'src/types';
 import { getEvent, getEventNameInLanguage } from './getEvent';
-import { getStorage, ref, uploadBytes, getDownloadURL } from 'firebase/storage';
+import { showNotification } from './showNotification';
 
 export const createEvent = async (newEvent: IEvent, image: File): Promise<boolean> => {
   const event = await getEvent(newEvent.id);
@@ -38,4 +40,22 @@ export const createEvent = async (newEvent: IEvent, image: File): Promise<boolea
 
     return false;
   }
+};
+
+export const isCreateFormDirty = (
+  newEvent: Omit<IEvent, 'id' | 'languageSpecificData' | 'image' | 'ageMin' | 'ageMax' | 'status'>,
+  languageSpecificData: IEvent['languageSpecificData'],
+  maxVolunteersAge: number,
+  minVolunteersAge: number,
+  eventStatus: IEvent['status']
+): boolean => {
+  return (
+    Object.values(newEvent).some(value => !!value) ||
+    Object.values(languageSpecificData.data).some(
+      lang => !!lang.name || !!lang.description || !!lang.place
+    ) ||
+    minVolunteersAge !== DEFAULT_MIN_AGE ||
+    maxVolunteersAge !== DEFAULT_MAX_AGE ||
+    eventStatus !== EventStatus.Draft
+  );
 };


### PR DESCRIPTION
1. Fix the issue with the style of language specific elements, first element was always displayed as last. 
2. Fix modal style - it now has a fixed position and when it is opened, the body is not scrollable.
3. Add logic to 'return' button on the create event page, it now only ask leave confirmation if user has changed anything.
4. Fix logic with redirecting to events list page from events creation page. It was always setting 'isError'=true for events list due to wrong arguments order in the function. 
5. Make leave alert message be shown on page reload or closing the tab.